### PR TITLE
RRBS fill hook & more straightforward trimmer spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python
+*.pyc
+
+# IDEs
+.idea/
+

--- a/src/rrbs.py
+++ b/src/rrbs.py
@@ -415,8 +415,10 @@ if args.epilog:
 	cmd += " --outfile=" + epilog_outfile
 	cmd += " --summary-filename=" + epilog_summary_file
 	cmd += " --cores=" + str(pm.cores)
+	cmd += " --qual-threshold=" + str(param.epilog.qual_threshold)
+	cmd += " --read-length-threshold=" + str(param.epilog.read_length_threshold)
+	cmd += " --rrbs-fill=" + str(args.rrbs_fill)
 	cmd += " --use-strand"    # Strand mode required because this isn't a bismark alignment.
-	cmd += " --rrbs-fill={}".format(args.rrbs_fill)
 
 	pm.run(cmd, epilog_outfile, nofail=True)
 

--- a/src/rrbs.py
+++ b/src/rrbs.py
@@ -59,7 +59,7 @@ pm.config.resources.genomes_split = os.path.join(pm.config.resources.resources, 
 pm.config.resources.bismark_spikein_genome = os.path.join(pm.config.resources.genomes, pm.config.resources.spikein_genome, "indexed_bismark_bt1")
 
 # Epilog indexes
-pm.config.resources.methpositions = os.path.join(pm.config.resources.genomes, args.genome_assembly, "indexed_epilog", args.genome_assembly + "_index.tsv.gz")
+pm.config.resources.methpositions = os.path.join(pm.config.resources.genomes, args.genome_assembly, "indexed_epilog", args.genome_assembly + "_cg.tsv.gz")
 pm.config.resources.spikein_methpositions = os.path.join(pm.config.resources.genomes, pm.config.resources.spikein_genome, "indexed_epilog", pm.config.resources.spikein_genome + "_index.tsv.gz")
 
 pm.config.parameters.pipeline_outfolder = outfolder

--- a/src/rrbs.py
+++ b/src/rrbs.py
@@ -25,23 +25,24 @@ parser = ArgumentParser(description='Pipeline')
 parser = pypiper.add_pypiper_args(parser, all_args=True)
 
 # Add any pipeline-specific arguments
-parser.add_argument('-t', '--trimgalore', dest='trimgalore', action="store_true",
+parser.add_argument("-t", "--trimgalore", dest="trimgalore", action="store_true",
 	help='Use trimgalore instead of trimmomatic?')
-
-parser.add_argument('-e', '--epilog', dest='epilog', action="store_true",
+parser.add_argument("-e", "--epilog", dest='epilog', action="store_true",
 	help='Use epilog for meth calling?')
-
-parser.add_argument('--pdr', dest='pdr', action="store_true",
+parser.add_argument("--pdr", dest="pdr", action="store_true",
 	help='Calculate Proportion of Discordant Reads (PDR)?')
-
+parser.add_argument("--rrbs-fill", dest="rrbs_fill", type=int, default=4,
+	help="Number of bases from read end to regard as unreliable and ignore due to RRBS chemistry")
 
 args = parser.parse_args()
 
+# Translate pypiper method of read type specification into flag-like option.
 if args.single_or_paired == "paired":
 	args.paired_end = True
 else:
 	args.paired_end = False
 
+# Input is required.
 if not args.input:
 	parser.print_help()
 	raise SystemExit
@@ -415,7 +416,7 @@ if args.epilog:
 	cmd += " --summary-filename=" + epilog_summary_file
 	cmd += " --cores=" + str(pm.cores)
 	cmd += " --use-strand"    # Strand mode required because this isn't a bismark alignment.
-	cmd += " --rrbs-fill=4"
+	cmd += " --rrbs-fill={}".format(args.rrbs_fill)
 
 	pm.run(cmd, epilog_outfile, nofail=True)
 

--- a/src/rrbs.yaml
+++ b/src/rrbs.yaml
@@ -59,3 +59,8 @@ parameters:
     genomeFraction: 50
     smartWindows: 250000
     maxProcesses: 4
+
+  epilog:
+    rrbs_fill: 4
+    qual_threshold: 30
+    read_length_threshold: 30

--- a/src/wgbs.py
+++ b/src/wgbs.py
@@ -464,7 +464,9 @@ if args.epilog:
 	cmd += " --outfile=" + epilog_outfile
 	cmd += " --summary-filename=" + epilog_summary_file
 	cmd += " --cores=" + str(pm.cores)
-	cmd += " --rrbs-fill=0"    # Turn off RRBS mode
+	cmd += " --qual-threshold=" + str(param.epilog.qual_threshold)
+	cmd += " --read-length-threshold=" + str(param.epilog.read_length_threshold)
+	cmd += " --wgbs"    # Turn off RRBS mode
 
 	pm.run(cmd, epilog_outfile, nofail=True)
 
@@ -565,7 +567,7 @@ if resources.bismark_spikein_genome:
 	cmd += " --cores=" + str(pm.cores)
 	cmd += " --qual-threshold=30"
 	cmd += " --read-length-threshold=30"
-	cmd += " --rrbs-fill=0"    # no rrbs mode for WGBS pipeline
+	cmd += " --wgbs"    # No RRBS "fill-in"
 
 	pm.run(cmd, epilog_spike_outfile, nofail=True)
 

--- a/src/wgbs.yaml
+++ b/src/wgbs.yaml
@@ -34,3 +34,6 @@ parameters:
   bismark:
     nondirectional: false
     maxins: 5000
+  epilog:
+    qual_threshold: 30
+    read_length_threshold: 30


### PR DESCRIPTION
User side: enables switching around the RRBS fill parameter for epilog
Dev side: while `trimgalore` is deprecated, this makes it easier to see how the trimmer option is being used and is affecting the control flow